### PR TITLE
Upgrade minimum JAX version to 0.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jax[cpu]>=0.4.26
+jax[cpu]>=0.5.1
 absl-py
 orbax-checkpoint
 uvicorn


### PR DESCRIPTION
Upgrade minimum JAX version to 0.5.1 based on offline e2e testing across JAX, pathwaysutils, Maxtext and Pathways Images. 0.5.1 was the minimum version that the latest tagged images were successful with.