### PR TITLE
Update the github action for PyPI

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -41,10 +41,10 @@ jobs:
     - name: Install pypa/build
       run: pip install build
     - name: Clone pathwaysutils from tag
-      if: github.event_name == 'worfklow_dispatch'
+      if: github.event_name == 'workflow_dispatch'
       run: git clone --branch=${{inputs.tag}} https://github.com/AI-Hypercomputer/pathways-utils.git
     - name: Enter directory
-      if: github.event_name == 'worfklow_dispatch'
+      if: github.event_name == 'workflow_dispatch'
       run: cd pathways-utils
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
@@ -55,7 +55,7 @@ jobs:
         path: dist/
 
   publish-to-testpypi:
-    if: ${{inputs.testpypi}} == true
+    if: inputs.testpypi
     name: Publish Python distribution to TestPyPI
     needs:
     - build
@@ -79,7 +79,7 @@ jobs:
 
   publish-to-pypi:
     name: Publish Python distribution to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: !inputs.testpypi && startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Today I realized two things about the PyPI GitHub action

1. The publish-to-pypi job runs if the testpypi input is set.
2. The tag input was ignored because the step that depended on it had a typo in the condition.

We were lucky that there was no issue from the initial publish and there were no other commits and it seems the extra `git clone` with a specific tag and `cd` into the cloned repo were unnecessary since there were no other commits since the release was created so 1. and 2. were not problems this release.