### PR TITLE
JAX version updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
-        jax-version: ['0.6.2', '0.7.0', '0.7.1', '0.7.2', '0.8.0', '0.8.1', 'nightly']
+        jax-version: ['0.7.0', '0.7.1', '0.7.2', '0.8.0', '0.8.1', '0.8.2', 'nightly']
 
         exclude:
-          - python-version: '3.14'
-            jax-version: '0.6.2'
           - python-version: '3.14'
             jax-version: '0.7.0'
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = []
 dependencies = [
     "absl-py",
     "fastapi",
-    "jax>=0.4.26",
+    "jax>=0.7.0",
     "orbax-checkpoint",
     "uvicorn",
     "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-jax[cpu]>=0.5.1
-absl-py
-orbax-checkpoint
-uvicorn
-fastapi
-google-cloud-logging


### PR DESCRIPTION
* Included the latest stable version of JAX in GitHub actions.
* Bumped the requirment to jax>=0.7.0.
* Removed requirements.txt and rely exclusively on pyproject.toml.