### PR TITLE
Revert "JAX version updates"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
-        jax-version: ['0.7.0', '0.7.1', '0.7.2', '0.8.0', '0.8.1', '0.8.2', 'nightly']
+        jax-version: ['0.6.2', '0.7.0', '0.7.1', '0.7.2', '0.8.0', '0.8.1', 'nightly']
 
         exclude:
+          - python-version: '3.14'
+            jax-version: '0.6.2'
           - python-version: '3.14'
             jax-version: '0.7.0'
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = []
 dependencies = [
     "absl-py",
     "fastapi",
-    "jax>=0.7.0",
+    "jax>=0.4.26",
     "orbax-checkpoint",
     "uvicorn",
     "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+jax[cpu]>=0.5.1
+absl-py
+orbax-checkpoint
+uvicorn
+fastapi
+google-cloud-logging


### PR DESCRIPTION
Reverts AI-Hypercomputer/pathways-utils#151

We will keep support for JAX 0.6.2 for the next release