### PR TITLE
bump py version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata
 name = "pathwaysutils"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [{name = "Pathways-on-Cloud Utilities Developers", email="pathwaysutils-dev@google.com"}]
 classifiers = [  # List of https://pypi.org/classifiers/


### PR DESCRIPTION
We don't test 3.10 so 3.11 should be the minimum version