### PR TITLE
Add [gke] and [test] optional dependencies with kubernetes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,15 @@ dev = [
     "pylint>=2.6.0",
     "pyink",
 ]
+gke = [
+    "kubernetes",
+    "pyyaml",
+]
+test = [
+    "kubernetes",
+    "pyyaml",
+    "pytest",
+]
 
 [tool.pyink]
 # Formatting configuration to follow Google style-guide

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ orbax-checkpoint
 uvicorn
 requests
 packaging
+kubernetes
+pyyaml


### PR DESCRIPTION
## Motivation (Why)
Pathways on Cloud GKE utilities and unit tests require `kubernetes` and `pyyaml`. Declaring optional dependency extras `[gke]` and `[test]` in `pyproject.toml` and updating `requirements.txt` allows users to install GKE extras (`pip install 'pathwaysutils[gke]'`) and CI runners to install test dependencies (`pip install 'pathwaysutils[test]'`).

## Implementation (How)
- Update `pyproject.toml` to add `gke` (`kubernetes`, `pyyaml`) and `test` (`kubernetes`, `pyyaml`, `pytest`) to `[project.optional-dependencies]`.
- Update `requirements.txt` to include `kubernetes` and `pyyaml`.

## Impact (What)
- Enables `pip install 'pathwaysutils[gke]'` and `pip install 'pathwaysutils[test]'`.
- Prepares dependency configuration for the upcoming PathwaysJobSet GKE headless refactor.
