### PR TITLE
Add dependency httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ gke = [
     "pyyaml",
 ]
 test = [
+    "httpx",
     "kubernetes",
     "pyyaml",
     "pytest",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 absl-py
 fastapi
+httpx
 jax>=0.8.0
 orbax-checkpoint
 uvicorn


### PR DESCRIPTION
Module httpx is needed to create a test client in fastapi server testing.